### PR TITLE
bench: add benchmarks for getenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .idea/
 
 /target
+/itconfig-tests/target
+
 Cargo.lock
 
 itconfig/src/main.rs

--- a/itconfig-tests/Cargo.toml
+++ b/itconfig-tests/Cargo.toml
@@ -10,7 +10,13 @@ publish = false
 
 [dependencies]
 itconfig = { path = '../itconfig' }
+criterion = "0.3.1"
+lazy_static = "1.4.0"
 
 [features]
 default = ["meta_namespace"]
 meta_namespace = []
+
+[[bench]]
+name = "main_benches"
+harness = false

--- a/itconfig-tests/benches/main_benches.rs
+++ b/itconfig-tests/benches/main_benches.rs
@@ -1,0 +1,58 @@
+use criterion::{Criterion, criterion_main, criterion_group, Fun};
+use std::env;
+
+#[macro_use]
+extern crate lazy_static;
+
+
+
+fn setup_env_var(initial: &String) {
+    env::set_var("TEST", initial);
+}
+
+
+fn source_get_env() -> u32 {
+    itconfig::get_env::<u32>("TEST").unwrap()
+}
+
+
+fn lazy_get_env() -> u32 {
+    lazy_static! {
+        static ref RES: u32 = source_get_env();
+    };
+
+    return *RES;
+}
+
+
+fn source_vs_lazy(c: &mut Criterion) {
+    let source = Fun::new("source", |b, initial: &String| {
+        setup_env_var(initial);
+        let int: u32 = initial.parse().unwrap();
+
+        b.iter(move || {
+            assert_eq!(source_get_env(), int)
+        })
+    });
+    let lazy = Fun::new("lazy", |b, initial: &String| {
+        setup_env_var(initial);
+        let int: u32 = initial.parse().unwrap();
+
+        b.iter(move || {
+            assert_eq!(lazy_get_env(), int);
+        })
+    });
+
+    let funcs = vec![source, lazy];
+
+    c.bench_functions("get_env", funcs, "1".to_string());
+}
+
+
+
+criterion_group! {
+    benches,
+    source_vs_lazy,
+}
+
+criterion_main!(benches);


### PR DESCRIPTION
Added benchmarks for get env function and use lazy get env.

```
get_env/source          time:   [418.50 ns 419.99 ns 421.60 ns]   
get_env/lazy            time:   [1.2967 ns 1.2994 ns 1.3024 ns] 
``` 