### PR TITLE
feat: add lazy static

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_cache:
 script:
   - |
     rustc --version &&
-    cargo test
+    cargo test --all-features
 matrix:
   allow_failures:
     - rust: nightly

--- a/README.md
+++ b/README.md
@@ -43,14 +43,16 @@ config! {
     ),
     
     APP {
+        static BASE_URL => "/api", // &'static str by default
+    
         ARTICLE {
-            PER_PAGE: u32 => 15,
+            static PER_PAGE: u32 => 15,
         }
         
         #[cfg(feature = "companies")]
         COMPANY {
             #[env_name = "INSTITUTIONS_PER_PAGE"]
-            PER_PAGE: u32 => 15,
+            static PER_PAGE: u32 => 15,
         }
     }
     
@@ -117,30 +119,30 @@ cargo test
 
 ## Available features
 
-* default = ["macro", "primitives"]
-* macro = []
-* array = ["serde_json"]
-* primitives = ["numbers", "bool"]
-* numbers = ["int", "uint", "float"]
-* int = ["i8", "i16", "i32", "i64", "i128", "isize"]
-* uint = ["u8", "u16", "u32", "u64", "u128", "usize"]
-* float = ["f32", "f64"]
-* i8    = []
-* i16   = []
-* i32   = []
-* i64   = []
-* i128  = []
-* isize = []
-* u8    = []
-* u16   = []
-* u32   = []
-* u64   = []
-* u128  = []
-* usize = []
-* f32   = []
-* f64   = []
-* bool  = []
-
+* **default** - ["macro", "primitives"]
+* **macro** - Activates `config!` macros for easy configure web application.
+* **static** - Add `static` option to `config!` macros (uses optional `lazy_static` package).
+* **array** - Add EnvString impl for vector type (uses optional `serde_json` package).
+* **primitives** - Group for features: `numbers` and `bool`.
+* **numbers** - Group for features: `int`, `uint` and `float`.
+* **int** - Group for features: `i8`, `i16`, `i32`, `i64`, `i128` and `isize`.
+* **uint** - Group for features: `u8`, `u16`, `u32`, `u64`, `u128` and `usize`.
+* **float** - Group for features: `f32` and `f64`
+* **i8** - impl EnvString for i8 type
+* **i16** - impl EnvString for i16 type
+* **i32** - impl EnvString for i32 type
+* **i64** - impl EnvString for i64 type
+* **i128** - impl EnvString for i128 type
+* **isize** - impl EnvString for isize type
+* **u8** - impl EnvString for u8 type
+* **u16** - impl EnvString for u16 type
+* **u32** - impl EnvString for u32 type
+* **u64** - impl EnvString for u64 type
+* **u128** - impl EnvString for u128 type
+* **usize** - impl EnvString for usize type
+* **f32** - impl EnvString for f32 type
+* **f64** - impl EnvString for f64 type
+* **bool** - impl EnvString for bool type
 
 ## License
 

--- a/itconfig-tests/Cargo.toml
+++ b/itconfig-tests/Cargo.toml
@@ -14,8 +14,9 @@ criterion = "0.3.1"
 lazy_static = "1.4.0"
 
 [features]
-default = ["meta_namespace"]
+default = ["meta_namespace", "static"]
 meta_namespace = []
+static = ["itconfig/static"]
 
 [[bench]]
 name = "main_benches"

--- a/itconfig-tests/tests/config_macro.rs
+++ b/itconfig-tests/tests/config_macro.rs
@@ -422,3 +422,51 @@ fn concatenated_environment_variable_in_namespace() {
     );
     assert_eq!(env::var("CONCAT_ENVVAR"), Err(VarError::NotPresent));
 }
+
+
+#[test]
+#[cfg(feature = "static")]
+fn static_variables() {
+    config! {
+        static STATIC_STR => "test",
+        static STATIC_STRING: String => "test",
+        static STATIC_I8: i8 => 1,
+        static STATIC_I16: i16 => 1,
+        static STATIC_I32: i32 => 1,
+        static STATIC_I64: i64 => 1,
+        static STATIC_I128: i128 => 1,
+        static STATIC_ISIZE: isize => 1,
+        static STATIC_U8: u8 => 1,
+        static STATIC_U16: u16 => 1,
+        static STATIC_U32: u32 => 1,
+        static STATIC_U64: u64 => 1,
+        static STATIC_U128: u128 => 1,
+        static STATIC_USIZE: usize => 1,
+        static STATIC_F32: f32 => 1,
+        static STATIC_F64: f64 => 1,
+        static STATIC_CONCAT_VARIABLE < (
+            "static ",
+            STATIC_CONCAT_PART => "part",
+        ),
+    }
+
+    cfg::init();
+
+    assert_eq!(cfg::STATIC_STR(), "test");
+    assert_eq!(cfg::STATIC_STRING(), "test".to_string());
+    assert_eq!(cfg::STATIC_I8(), 1);
+    assert_eq!(cfg::STATIC_I16(), 1);
+    assert_eq!(cfg::STATIC_I32(), 1);
+    assert_eq!(cfg::STATIC_I64(), 1);
+    assert_eq!(cfg::STATIC_I128(), 1);
+    assert_eq!(cfg::STATIC_ISIZE(), 1);
+    assert_eq!(cfg::STATIC_U8(), 1);
+    assert_eq!(cfg::STATIC_U16(), 1);
+    assert_eq!(cfg::STATIC_U32(), 1);
+    assert_eq!(cfg::STATIC_U64(), 1);
+    assert_eq!(cfg::STATIC_U128(), 1);
+    assert_eq!(cfg::STATIC_USIZE(), 1);
+    assert_eq!(cfg::STATIC_F32(), 1.0);
+    assert_eq!(cfg::STATIC_F64(), 1.0);
+    assert_eq!(cfg::STATIC_CONCAT_VARIABLE(), "static part".to_string())
+}

--- a/itconfig/Cargo.toml
+++ b/itconfig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itconfig"
-version = "0.10.2"
+version = "0.11.0"
 authors = ["Dmitriy Pleshevskiy <dmitriy@ideascup.me>"]
 description = "Easy build a configs from environment variables and use it in globally."
 categories = ["config", "web-programming"]
@@ -16,11 +16,14 @@ readme = "README.md"
 
 [dependencies]
 failure = { version = "0.1.6", features = ["derive"]}
+lazy_static = { version = "1.4.0", optional = true }
 serde_json = { version = "1.0.44", optional = true }
 
 [features]
-default = ["macro", "primitives"]
+default = ["macro", "primitives", "static"]
+
 macro = []
+static = ["lazy_static"]
 
 array = ["serde_json"]
 

--- a/itconfig/Cargo.toml
+++ b/itconfig/Cargo.toml
@@ -20,7 +20,7 @@ lazy_static = { version = "1.4.0", optional = true }
 serde_json = { version = "1.0.44", optional = true }
 
 [features]
-default = ["macro", "primitives", "static"]
+default = ["macro", "primitives"]
 
 macro = []
 static = ["lazy_static"]

--- a/itconfig/README.md
+++ b/itconfig/README.md
@@ -30,14 +30,16 @@ config! {
     ),
     
     APP {
+        static BASE_URL => "/api", // &'static str by default
+    
         ARTICLE {
-            PER_PAGE: u32 => 15,
+            static PER_PAGE: u32 => 15,
         }
         
         #[cfg(feature = "companies")]
         COMPANY {
             #[env_name = "INSTITUTIONS_PER_PAGE"]
-            PER_PAGE: u32 => 15,
+            static PER_PAGE: u32 => 15,
         }
     }
     
@@ -98,29 +100,30 @@ fn main() {
 
 ## Available features
 
-* default = ["macro", "primitives"]
-* macro = []
-* array = ["serde_json"]
-* primitives = ["numbers", "bool"]
-* numbers = ["int", "uint", "float"]
-* int = ["i8", "i16", "i32", "i64", "i128", "isize"]
-* uint = ["u8", "u16", "u32", "u64", "u128", "usize"]
-* float = ["f32", "f64"]
-* i8    = []
-* i16   = []
-* i32   = []
-* i64   = []
-* i128  = []
-* isize = []
-* u8    = []
-* u16   = []
-* u32   = []
-* u64   = []
-* u128  = []
-* usize = []
-* f32   = []
-* f64   = []
-* bool  = []
+* **default** - ["macro", "primitives"]
+* **macro** - Activates `config!` macros for easy configure web application.
+* **static** - Add `static` option to `config!` macros (uses optional `lazy_static` package).
+* **array** - Add EnvString impl for vector type (uses optional `serde_json` package).
+* **primitives** - Group for features: `numbers` and `bool`.
+* **numbers** - Group for features: `int`, `uint` and `float`.
+* **int** - Group for features: `i8`, `i16`, `i32`, `i64`, `i128` and `isize`.
+* **uint** - Group for features: `u8`, `u16`, `u32`, `u64`, `u128` and `usize`.
+* **float** - Group for features: `f32` and `f64`
+* **i8** - impl EnvString for i8 type
+* **i16** - impl EnvString for i16 type
+* **i32** - impl EnvString for i32 type
+* **i64** - impl EnvString for i64 type
+* **i128** - impl EnvString for i128 type
+* **isize** - impl EnvString for isize type
+* **u8** - impl EnvString for u8 type
+* **u16** - impl EnvString for u16 type
+* **u32** - impl EnvString for u32 type
+* **u64** - impl EnvString for u64 type
+* **u128** - impl EnvString for u128 type
+* **usize** - impl EnvString for usize type
+* **f32** - impl EnvString for f32 type
+* **f64** - impl EnvString for f64 type
+* **bool** - impl EnvString for bool type
 
 
 ## License

--- a/itconfig/src/envstr.rs
+++ b/itconfig/src/envstr.rs
@@ -119,6 +119,15 @@ impl FromEnvString for String {
 }
 
 
+impl FromEnvString for &'static str {
+    type Err = ();
+
+    fn from_env_string(s: &EnvString) -> Result<Self, Self::Err> {
+        Ok(Box::leak(s.0.clone().into_boxed_str()))
+    }
+}
+
+
 #[doc(hidden)]
 #[derive(Debug, PartialEq, Clone)]
 pub struct EnvString(String);

--- a/itconfig/src/envstr.rs
+++ b/itconfig/src/envstr.rs
@@ -76,6 +76,7 @@ impl FromEnvString for bool {
 
 
 #[cfg(feature = "array")]
+#[derive(Debug)]
 pub enum ArrayEnvError {
     InvalidType,
     FailedToParse,

--- a/itconfig/src/lib.rs
+++ b/itconfig/src/lib.rs
@@ -87,12 +87,14 @@
 
 
 // Rustc lints.
-#![deny(unused_imports)]
+//#![deny(unused_imports)]
 
 /////////////////////////////////////////////////////////////////////////////
 
 #[macro_use]
 extern crate failure;
+#[cfg(feature = "static")]
+extern crate lazy_static;
 
 mod enverr;
 mod getenv;
@@ -108,7 +110,7 @@ pub mod prelude {
 
 
 #[cfg(feature = "macro")]
-#[allow(unused_imports)]
+//#[allow(unused_imports)]
 #[macro_use]
 mod r#macro;
 #[cfg(feature = "macro")]

--- a/itconfig/src/lib.rs
+++ b/itconfig/src/lib.rs
@@ -35,14 +35,16 @@
 //!     ),
 //!
 //!     APP {
+//!         static BASE_URL => "/api", // &'static str by default
+//!
 //!         ARTICLE {
-//!             PER_PAGE: u32 => 15,
+//!             static PER_PAGE: u32 => 15,
 //!         }
 //!
 //!         #[cfg(feature = "companies")]
 //!         COMPANY {
 //!             #[env_name = "INSTITUTIONS_PER_PAGE"]
-//!             PER_PAGE: u32 => 15,
+//!             static PER_PAGE: u32 => 15,
 //!         }
 //!     }
 //!
@@ -62,6 +64,7 @@
 //!     cfg::init();
 //!     assert_eq!(cfg::HOST(), String::from("127.0.0.1"));
 //!     assert_eq!(cfg::DATABASE_URL(), String::from("postgres://user:pass@localhost:5432/test"));
+//!     assert_eq!(cfg::APP::BASE_URL(), "/api");
 //!     assert_eq!(cfg::APP::ARTICLE::PER_PAGE(), 15);
 //!     assert_eq!(cfg::FEATURE::NEW_MENU(), true);
 //! }
@@ -84,10 +87,43 @@
 //! }
 //! ```
 //!
+//! ## Available features
+//!
+//! * **default** - ["macro", "primitives"]
+//! * **macro** - Activates `config!` macros for easy configure web application.
+//! * **static** - Add `static` option to `config!` macros (uses optional `lazy_static` package).
+//! * **array** - Add EnvString impl for vector type (uses optional `serde_json` package).
+//! * **primitives** - Group for features: `numbers` and `bool`.
+//! * **numbers** - Group for features: `int`, `uint` and `float`.
+//! * **int** - Group for features: `i8`, `i16`, `i32`, `i64`, `i128` and `isize`.
+//! * **uint** - Group for features: `u8`, `u16`, `u32`, `u64`, `u128` and `usize`.
+//! * **float** - Group for features: `f32` and `f64`
+//! * **i8** - impl EnvString for i8 type
+//! * **i16** - impl EnvString for i16 type
+//! * **i32** - impl EnvString for i32 type
+//! * **i64** - impl EnvString for i64 type
+//! * **i128** - impl EnvString for i128 type
+//! * **isize** - impl EnvString for isize type
+//! * **u8** - impl EnvString for u8 type
+//! * **u16** - impl EnvString for u16 type
+//! * **u32** - impl EnvString for u32 type
+//! * **u64** - impl EnvString for u64 type
+//! * **u128** - impl EnvString for u128 type
+//! * **usize** - impl EnvString for usize type
+//! * **f32** - impl EnvString for f32 type
+//! * **f64** - impl EnvString for f64 type
+//! * **bool** - impl EnvString for bool type
+//!a
 
 
 // Rustc lints.
-//#![deny(unused_imports)]
+#![deny(
+    missing_debug_implementations,
+    unsafe_code,
+    unstable_features,
+    unused_imports,
+    unused_qualifications,
+)]
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/itconfig/src/macro.rs
+++ b/itconfig/src/macro.rs
@@ -303,6 +303,14 @@ macro_rules! __itconfig_parse_module {
 
 #[macro_export]
 #[doc(hidden)]
+macro_rules! __itconfig_get_ty_or_default {
+    () => { &'static str };
+    ($ty:ty) => { $ty };
+}
+
+
+#[macro_export]
+#[doc(hidden)]
 macro_rules! __itconfig_parse_variables {
     // Find namespace
     (
@@ -329,6 +337,30 @@ macro_rules! __itconfig_parse_variables {
         }
     };
 
+    // Find static concatenated variable
+    (
+        tokens = [
+            $(#$meta:tt)*
+            static $name:ident < ($($inner:tt)+),
+            $($rest:tt)*
+        ],
+        $($args:tt)*
+    ) => {
+        __itconfig_parse_variables! {
+            current_variable = {
+                unparsed_meta = [$(#$meta)*],
+                meta = [],
+                unparsed_concat = [$($inner)+],
+                concat = [],
+                name = $name,
+                ty = String,
+                is_static = true,
+            },
+            tokens = [$($rest)*],
+            $($args)*
+        }
+    };
+
     // Find concatenated variable
     (
         tokens = [
@@ -346,17 +378,18 @@ macro_rules! __itconfig_parse_variables {
                 concat = [],
                 name = $name,
                 ty = String,
+                is_static = false,
             },
             tokens = [$($rest)*],
             $($args)*
         }
     };
 
-    // Find variable
+    // Find static variable
     (
         tokens = [
             $(#$meta:tt)*
-            $name:ident : $ty:ty$( => $default:expr)?,
+            static $name:ident $(: $ty:ty)? $(=> $default:expr)?,
             $($rest:tt)*
         ],
         $($args:tt)*
@@ -368,7 +401,33 @@ macro_rules! __itconfig_parse_variables {
                 unparsed_concat = [],
                 concat = [],
                 name = $name,
-                ty = $ty,
+                ty = __itconfig_get_ty_or_default!($($ty)?),
+                is_static = true,
+                $(default = $default,)?
+            },
+            tokens = [$($rest)*],
+            $($args)*
+        }
+    };
+
+    // Find variable
+    (
+        tokens = [
+            $(#$meta:tt)*
+            $name:ident $(: $ty:ty)? $(=> $default:expr)?,
+            $($rest:tt)*
+        ],
+        $($args:tt)*
+    ) => {
+        __itconfig_parse_variables! {
+            current_variable = {
+                unparsed_meta = [$(#$meta)*],
+                meta = [],
+                unparsed_concat = [],
+                concat = [],
+                name = $name,
+                ty = __itconfig_get_ty_or_default!($($ty)?),
+                is_static = false,
                 $(default = $default,)?
             },
             tokens = [$($rest)*],
@@ -523,6 +582,9 @@ macro_rules! __itconfig_impl_namespace {
             meta = $var_meta:tt,
             concat = $var_concat:tt,
             name = $var_name:ident,
+            $(env_name = $env_name:expr,)?
+            ty = $ty:ty,
+            is_static = $is_static:ident,
             $($variable:tt)*
         },)*],
         namespaces = [$({
@@ -543,6 +605,8 @@ macro_rules! __itconfig_impl_namespace {
         $(#$meta)*
         pub mod $mod_name {
             #![allow(non_snake_case)]
+            #[cfg(feature = "static")]
+            use lazy_static::lazy_static;
 
             $(__itconfig_impl_namespace! {
                 variables = $ns_variable,
@@ -567,6 +631,9 @@ macro_rules! __itconfig_impl_namespace {
                 concat = $var_concat,
                 name = $var_name,
                 env_prefix = $env_prefix,
+                $(env_name = $env_name,)?
+                ty = $ty,
+                is_static = $is_static,
                 $($variable)*
             })*
         }
@@ -630,24 +697,61 @@ macro_rules! __itconfig_variable {
 
     // Add method for env variable
     (
-        meta = [$(#$meta:tt,)*],
+        meta = $meta:tt,
         concat = $concat:tt,
         name = $name:ident,
         env_prefix = $env_prefix:expr,
         env_name = $env_name:expr,
         ty = $ty:ty,
+        is_static = $is_static:ident,
         $(default = $default:expr,)?
     ) => {
-        $(#$meta)*
-        pub fn $name() -> $ty {
-            __itconfig_variable! {
+        __itconfig_variable!(
+            @wrap
+            is_static = $is_static,
+            meta = $meta,
+            name = $name,
+            ty = $ty,
+            value = __itconfig_variable!(
                 @inner
                 concat = $concat,
                 env_name = $env_name,
                 $(default = $default,)?
-            }
-        }
+            ),
+        );
     };
+
+    // Wrap static variables
+    (
+        @wrap
+        is_static = true,
+        meta = [$(#$meta:tt,)*],
+        name = $name:ident,
+        ty = $ty:ty,
+        value = $value:expr,
+    ) => (
+        $(#$meta)*
+        pub fn $name() -> $ty {
+            lazy_static! {
+                static ref $name: $ty = $value;
+            }
+
+            (*$name).clone()
+        }
+    );
+
+    // Wrap functions
+    (
+        @wrap
+        is_static = false,
+        meta = [$(#$meta:tt,)*],
+        name = $name:ident,
+        ty = $ty:ty,
+        value = $value:expr,
+    ) => (
+        $(#$meta)*
+        pub fn $name() -> $ty { $value }
+    );
 
     // Concatenate function body
     (
@@ -655,12 +759,12 @@ macro_rules! __itconfig_variable {
         concat = [$($concat:expr,)+],
         env_name = $env_name:expr,
         $($args:tt)*
-    ) => (
+    ) => ({
         let value_parts: Vec<String> = vec!($($concat),+);
         let value = value_parts.join("");
         std::env::set_var($env_name, value.as_str());
         value
-    );
+    });
 
     // Env without default
     (


### PR DESCRIPTION
I've added lazy static implementation for variables. Also added &'static str implementation. This type can be used by default

```rust
config! {
    static STATIC_STR => "test",
    static STATIC_STRING: String => "test",
    static STATIC_I8: i8 => 1,
    static STATIC_I16: i16 => 1,
    static STATIC_I32: i32 => 1,
    static STATIC_I64: i64 => 1,
    static STATIC_I128: i128 => 1,
    static STATIC_ISIZE: isize => 1,
    static STATIC_U8: u8 => 1,
    static STATIC_U16: u16 => 1,
    static STATIC_U32: u32 => 1,
    static STATIC_U64: u64 => 1,
    static STATIC_U128: u128 => 1,
    static STATIC_USIZE: usize => 1,
    static STATIC_F32: f32 => 1,
    static STATIC_F64: f64 => 1,
    static STATIC_CONCAT_VARIABLE < (
        "static ",
        STATIC_CONCAT_PART => "part",
    ),
}
```

Closes #13