### PR TITLE
feat: add vec supporting

### DIFF
--- a/itconfig-macro/src/ast.rs
+++ b/itconfig-macro/src/ast.rs
@@ -2,14 +2,14 @@ use crate::utils::SupportedBox;
 use proc_macro2::TokenStream as TokenStream2;
 use syn::{Attribute, Expr, Ident, Type};
 
-pub struct RootNamespace {
+pub(crate) struct RootNamespace {
     pub name: Option<Ident>,
     pub variables: Vec<Variable>,
     pub namespaces: Vec<Namespace>,
     pub meta: Vec<Attribute>,
 }
 
-pub struct Namespace {
+pub(crate) struct Namespace {
     pub name: Ident,
     pub variables: Vec<Variable>,
     pub namespaces: Vec<Namespace>,
@@ -17,7 +17,7 @@ pub struct Namespace {
     pub meta: Vec<Attribute>,
 }
 
-pub struct Variable {
+pub(crate) struct Variable {
     pub is_static: bool,
     pub name: Ident,
     pub ty: Type,

--- a/itconfig-macro/src/ast.rs
+++ b/itconfig-macro/src/ast.rs
@@ -1,3 +1,4 @@
+use crate::utils::SupportedBox;
 use proc_macro2::TokenStream as TokenStream2;
 use syn::{Attribute, Expr, Ident, Type};
 
@@ -24,4 +25,5 @@ pub struct Variable {
     pub concat_parts: Option<Vec<TokenStream2>>,
     pub env_name: Option<String>,
     pub meta: Vec<Attribute>,
+    pub supported_box: Option<SupportedBox>,
 }

--- a/itconfig-macro/src/expand.rs
+++ b/itconfig-macro/src/expand.rs
@@ -138,8 +138,8 @@ impl ToTokens for Variable {
             }}
         } else if let Some(initial) = &self.initial {
             match self.supported_box.clone() {
-                Some(SupportedBox::Vec(sep)) => {
-                    let sep = &sep.unwrap_or_else(|| String::from(","));
+                Some(SupportedBox::Vec(params)) => {
+                    let sep = &params.sep();
                     quote!(::itconfig::get_vec_env_or_set_default(#env_name, #sep, #initial))
                 }
                 _ => quote!(::itconfig::get_env_or_set_default(#env_name, #initial)),
@@ -149,12 +149,12 @@ impl ToTokens for Variable {
                 Some(SupportedBox::Option) => {
                     quote!(::itconfig::maybe_get_env(#env_name))
                 }
-                Some(SupportedBox::OptionVec(sep)) => {
-                    let sep = &sep.unwrap_or_else(|| String::from(","));
+                Some(SupportedBox::OptionVec(params)) => {
+                    let sep = &params.sep();
                     quote!(::itconfig::maybe_get_vec_env(#env_name, #sep))
                 }
-                Some(SupportedBox::Vec(sep)) => {
-                    let sep = &sep.unwrap_or_else(|| String::from(","));
+                Some(SupportedBox::Vec(params)) => {
+                    let sep = &params.sep();
                     quote!(::itconfig::get_vec_env_or_panic(#env_name, #sep))
                 }
                 None => {

--- a/itconfig-macro/src/expand.rs
+++ b/itconfig-macro/src/expand.rs
@@ -138,7 +138,7 @@ impl ToTokens for Variable {
             }}
         } else if let Some(initial) = &self.initial {
             match self.supported_box.clone() {
-                Some(SupportedBox::Vec { sep }) => {
+                Some(SupportedBox::Vec(sep)) => {
                     let sep = &sep.unwrap_or_else(|| String::from(","));
                     quote!(::itconfig::get_vec_env_or_set_default(#env_name, #sep, #initial))
                 }
@@ -149,11 +149,15 @@ impl ToTokens for Variable {
                 Some(SupportedBox::Option) => {
                     quote!(::itconfig::maybe_get_env(#env_name))
                 }
-                Some(SupportedBox::Vec { sep }) => {
+                Some(SupportedBox::OptionVec(sep)) => {
+                    let sep = &sep.unwrap_or_else(|| String::from(","));
+                    quote!(::itconfig::maybe_get_vec_env(#env_name, #sep))
+                }
+                Some(SupportedBox::Vec(sep)) => {
                     let sep = &sep.unwrap_or_else(|| String::from(","));
                     quote!(::itconfig::get_vec_env_or_panic(#env_name, #sep))
                 }
-                _ => {
+                None => {
                     quote!(::itconfig::get_env_or_panic(#env_name))
                 }
             }

--- a/itconfig-macro/src/parse.rs
+++ b/itconfig-macro/src/parse.rs
@@ -75,9 +75,9 @@ fn parse_namespace_content(
                 variable.env_name = parse_attribute(attr, "env_name", &variable.env_name)?;
             } else {
                 match variable.supported_box {
-                    Some(SupportedBox::Vec { sep: current_sep }) if attr.path.is_ident("sep") => {
+                    Some(SupportedBox::Vec(current_sep)) if attr.path.is_ident("sep") => {
                         let sep = parse_attribute(attr, "sep", &current_sep)?;
-                        variable.supported_box = Some(SupportedBox::Vec { sep });
+                        variable.supported_box = Some(SupportedBox::Vec(sep));
                     }
                     _ => variable.meta.push(attr),
                 }

--- a/itconfig-macro/src/utils.rs
+++ b/itconfig-macro/src/utils.rs
@@ -5,9 +5,9 @@ use syn::{Path, Type};
 const OPTION_PATH_IDENTS: &[&str] = &["Option|", "std|option|Option|", "core|option|Option|"];
 const VEC_PATH_IDENTS: &[&str] = &["Vec|", "std|vec|Vec|"];
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum SupportedBox {
-    Vec,
+    Vec { sep: Option<String> },
     Option,
 }
 
@@ -44,7 +44,7 @@ pub fn maybe_supported_box(ty: &Type) -> Option<SupportedBox> {
             if is_option_path_ident(&path_ident) {
                 Some(SupportedBox::Option)
             } else if is_vec_path_ident(&path_ident) {
-                Some(SupportedBox::Vec)
+                Some(SupportedBox::Vec { sep: None })
             } else {
                 None
             }

--- a/itconfig-macro/src/utils.rs
+++ b/itconfig-macro/src/utils.rs
@@ -5,14 +5,34 @@ use syn::{GenericArgument, Path, PathArguments, Type};
 const OPTION_PATH_IDENTS: &[&str] = &["Option|", "std|option|Option|", "core|option|Option|"];
 const VEC_PATH_IDENTS: &[&str] = &["Vec|", "std|vec|Vec|"];
 
-#[derive(Debug, Clone)]
-pub enum SupportedBox {
-    Vec(Option<String>),
-    Option,
-    OptionVec(Option<String>),
+#[derive(Debug, Clone, Default)]
+pub(crate) struct VecBoxParams(Option<String>);
+
+impl VecBoxParams {
+    #[inline]
+    pub(crate) fn new(sep: Option<String>) -> Self {
+        VecBoxParams(sep)
+    }
+
+    #[inline]
+    pub(crate) fn sep_opt(&self) -> Option<String> {
+        self.0.clone()
+    }
+
+    #[inline]
+    pub(crate) fn sep(&self) -> String {
+        self.0.clone().unwrap_or_else(|| String::from(","))
+    }
 }
 
-pub fn vec_to_token_stream_2<T>(input: &[T]) -> Vec<TokenStream2>
+#[derive(Debug, Clone)]
+pub(crate) enum SupportedBox {
+    Vec(VecBoxParams),
+    Option,
+    OptionVec(VecBoxParams),
+}
+
+pub(crate) fn vec_to_token_stream_2<T>(input: &[T]) -> Vec<TokenStream2>
 where
     T: ToTokens,
 {
@@ -38,27 +58,27 @@ fn is_vec_path_ident(path_ident: &str) -> bool {
     VEC_PATH_IDENTS.iter().any(|s| path_ident == *s)
 }
 
-pub fn maybe_supported_box(ty: &Type) -> Option<SupportedBox> {
+pub(crate) fn maybe_supported_box(ty: &Type) -> Option<SupportedBox> {
     match ty {
         Type::Path(ty_path) if ty_path.qself.is_none() => {
             let ty_path_ident = path_ident(&ty_path.path);
             if is_option_path_ident(&ty_path_ident) {
-                match &ty_path.path.segments.iter().last().unwrap().arguments {
-                    PathArguments::AngleBracketed(params) => match params.args.first() {
-                        Some(GenericArgument::Type(Type::Path(inner_ty_path))) => {
-                            let ty_path_ident = path_ident(&inner_ty_path.path);
-                            if is_vec_path_ident(&ty_path_ident) {
-                                Some(SupportedBox::OptionVec(None))
-                            } else {
-                                Some(SupportedBox::Option)
-                            }
+                if let PathArguments::AngleBracketed(params) =
+                    &ty_path.path.segments.iter().last().unwrap().arguments
+                {
+                    if let Some(GenericArgument::Type(Type::Path(inner_ty_path))) =
+                        params.args.first()
+                    {
+                        let ty_path_ident = path_ident(&inner_ty_path.path);
+                        if is_vec_path_ident(&ty_path_ident) {
+                            return Some(SupportedBox::OptionVec(Default::default()));
                         }
-                        _ => Some(SupportedBox::Option),
-                    },
-                    _ => Some(SupportedBox::Option),
+                    }
                 }
+
+                Some(SupportedBox::Option)
             } else if is_vec_path_ident(&ty_path_ident) {
-                Some(SupportedBox::Vec(None))
+                Some(SupportedBox::Vec(Default::default()))
             } else {
                 None
             }

--- a/itconfig-tests/Cargo.toml
+++ b/itconfig-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itconfig_tests"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Dmitriy Pleshevskiy <dmitriy@ideascup.me>"]
 edition = "2018"
 license = "MIT"

--- a/itconfig-tests/Cargo.toml
+++ b/itconfig-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itconfig_tests"
-version = "0.1.1"
+version = "0.1.0"
 authors = ["Dmitriy Pleshevskiy <dmitriy@ideascup.me>"]
 edition = "2018"
 license = "MIT"

--- a/itconfig-tests/tests/config_macro.rs
+++ b/itconfig-tests/tests/config_macro.rs
@@ -506,6 +506,7 @@ mod test_case_22 {
             "static ",
             STATIC_CONCAT_PART => "part",
         ),
+        static STATIC_VEC: Vec<u32> => vec![1],
     }
 
     #[test]
@@ -528,7 +529,8 @@ mod test_case_22 {
         assert_eq!(config::STATIC_USIZE(), 1);
         assert_eq!(config::STATIC_F32(), 1.0);
         assert_eq!(config::STATIC_F64(), 1.0);
-        assert_eq!(config::STATIC_CONCAT_VARIABLE(), "static part".to_string())
+        assert_eq!(config::STATIC_CONCAT_VARIABLE(), "static part".to_string());
+        assert_eq!(config::STATIC_VEC(), vec![1]);
     }
 }
 
@@ -571,5 +573,26 @@ mod test_case_24 {
 
         assert_eq!(config::MY_VEC(), vec!["paypal", "stripe"]);
         assert_eq!(config::STD_VEC(), vec!["paypal", "stripe"]);
+    }
+}
+
+mod test_case_25 {
+    use std::env;
+
+    itconfig::config! {
+        #[sep = ";"]
+        CUSTOM_SEP_MY_VEC: Vec<&'static str>,
+
+        #[env_name = "CUSTOM_SEP_MY_VEC"]
+        #[sep = ";"]
+        CUSTOM_SEP_STD_VEC: std::vec::Vec<&'static str>,
+    }
+
+    #[test]
+    fn custom_separator_for_vector() {
+        env::set_var("CUSTOM_SEP_MY_VEC", "paypal;stripe");
+
+        assert_eq!(config::CUSTOM_SEP_MY_VEC(), vec!["paypal", "stripe"]);
+        assert_eq!(config::CUSTOM_SEP_STD_VEC(), vec!["paypal", "stripe"]);
     }
 }

--- a/itconfig-tests/tests/config_macro.rs
+++ b/itconfig-tests/tests/config_macro.rs
@@ -547,13 +547,29 @@ mod test_case_23 {
 
     #[test]
     fn optional_variables() {
-        config::init();
-
         env::set_var("SOMETHING", "hello world");
 
         assert_eq!(config::SOMETHING(), Some("hello world"));
         assert_eq!(config::STD_SOMETHING(), Some("hello world"));
         assert_eq!(config::CORE_SOMETHING(), Some("hello world"));
         assert_eq!(config::NOTHING(), None);
+    }
+}
+
+mod test_case_24 {
+    use std::env;
+
+    itconfig::config! {
+        MY_VEC: Vec<&'static str>,
+        #[env_name = "MY_VEC"]
+        STD_VEC: std::vec::Vec<&'static str>,
+    }
+
+    #[test]
+    fn vector_of_values() {
+        env::set_var("MY_VEC", "paypal,stripe");
+
+        assert_eq!(config::MY_VEC(), vec!["paypal", "stripe"]);
+        assert_eq!(config::STD_VEC(), vec!["paypal", "stripe"]);
     }
 }

--- a/itconfig-tests/tests/config_macro.rs
+++ b/itconfig-tests/tests/config_macro.rs
@@ -596,3 +596,18 @@ mod test_case_25 {
         assert_eq!(config::CUSTOM_SEP_STD_VEC(), vec!["paypal", "stripe"]);
     }
 }
+
+mod test_case_26 {
+    use std::env;
+
+    itconfig::config! {
+        OPTION_VEC: Option<Vec<&'static str>>,
+    }
+
+    #[test]
+    fn optional_vec() {
+        env::set_var("OPTION_VEC", "paypal,stripe");
+
+        assert_eq!(config::OPTION_VEC(), Some(vec!["paypal", "stripe"]));
+    }
+}

--- a/itconfig/src/envstr.rs
+++ b/itconfig/src/envstr.rs
@@ -5,7 +5,7 @@ use std::ops::Deref;
 /// When we read the environment variable, we automatically convert the value
 /// to EnvString and then convert it to your expected type.
 ///
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct EnvString(String);
 
 impl<T> From<T> for EnvString

--- a/itconfig/src/get_env.rs
+++ b/itconfig/src/get_env.rs
@@ -1,5 +1,6 @@
 use crate::envstr::*;
 use crate::error::*;
+use crate::utils::*;
 use std::env;
 
 /// Same as get_env but returns Option enum instead Result
@@ -150,18 +151,6 @@ where
         .map(|s| s.to_env_string())
         .or_else(cb)
         .and_then(|env_str| parse_env_variable(env_name, env_str))
-}
-
-fn parse_env_variable<T>(env_name: &str, env_str: EnvString) -> Result<T, EnvError>
-where
-    T: FromEnvString,
-{
-    FromEnvString::from_env_string(&env_str)
-        .map_err(|_| EnvError::FailedToParse(env_name.to_string()))
-}
-
-fn make_panic<T>(e: EnvError) -> T {
-    panic!("{}", e)
 }
 
 #[cfg(test)]

--- a/itconfig/src/get_vec_env.rs
+++ b/itconfig/src/get_vec_env.rs
@@ -1,0 +1,322 @@
+use crate::envstr::*;
+use crate::error::*;
+use crate::utils::*;
+use std::env;
+
+/// Same as get_vec_env but returns Option enum instead Result
+///
+/// Example
+/// -------
+///
+/// ```rust
+/// # extern crate itconfig;
+/// # use itconfig::*;
+/// use std::env;
+///
+/// #[derive(Debug, PartialEq, Eq)]
+/// enum PaymentPlatform {
+///     PayPal,
+///     Stripe,
+///     SomethingElse,
+/// }
+///
+/// impl FromEnvString for PaymentPlatform {
+///     type Err = &'static str;
+///
+///     fn from_env_string(envstr: &EnvString) -> Result<Self, Self::Err> {
+///         match envstr.to_lowercase().as_str() {
+///             "paypal" => Ok(Self::PayPal),
+///             "stripe" => Ok(Self::Stripe),
+///             "smth" => Ok(Self::SomethingElse),
+///             _ => Err("Unsupported payment platform"),
+///         }
+///     }
+/// }
+///
+///
+/// fn main () {
+///     env::set_var("PAYMENT_PLATFORMS", "paypal,stripe");
+///
+///     let payment_platforms: Option<Vec<PaymentPlatform>> = maybe_get_vec_env("PAYMENT_PLATFORMS", ",");
+///     assert_eq!(
+///         payment_platforms,
+///         Some(vec![PaymentPlatform::PayPal, PaymentPlatform::Stripe])
+///     );
+/// }
+/// ```
+///
+pub fn maybe_get_vec_env<T>(env_name: &str, sep: &'static str) -> Option<Vec<T>>
+where
+    T: FromEnvString,
+{
+    get_vec_env(env_name, sep).ok()
+}
+
+/// This function is similar as `get_vec_env`, but it unwraps result with panic on error.
+///
+/// Panics
+/// ------
+/// Application will panic if environment variable is missing or cannot parse variable to
+/// expected type
+///
+pub fn get_vec_env_or_panic<T>(env_name: &str, sep: &'static str) -> Vec<T>
+where
+    T: FromEnvString,
+{
+    get_vec_env(env_name, sep).unwrap_or_else(make_panic)
+}
+
+/// Try to read environment variable, split by separator and parse each item to expected
+/// type.
+///
+/// Example
+/// -------
+///
+/// ```rust
+/// # extern crate itconfig;
+/// # use itconfig::get_vec_env;
+/// use std::env;
+///
+/// fn main () {
+///     env::set_var("DEBUG", "true");
+///
+///     let result: Vec<bool> = get_vec_env("DEBUG", ",").unwrap();
+///
+///     assert_eq!(result, vec![true]);
+/// }
+/// ```
+///
+pub fn get_vec_env<T>(env_name: &str, sep: &'static str) -> Result<Vec<T>, EnvError>
+where
+    T: FromEnvString,
+{
+    get_vec_env_or(env_name, sep, |_| {
+        Err(EnvError::MissingVariable(env_name.to_string()))
+    })
+}
+
+/// This function is similar as `get_vec_env_or_panic`, but you can pass default value for
+/// environment variable with `ToEnvString` trait.
+///
+/// Panics
+/// ------
+/// Application will panic if cannot parse variable to expected type
+///
+/// Example
+/// -------
+///
+/// ```rust
+/// # extern crate itconfig;
+/// # use itconfig::get_vec_env_or_default;
+/// use std::env;
+///
+/// fn main () {
+///     let result: Vec<bool> = get_vec_env_or_default("TESTING", ",", vec!["true"]);
+///     assert_eq!(result, vec![true]);
+/// }
+/// ```
+///
+pub fn get_vec_env_or_default<T, D>(env_name: &str, sep: &'static str, default: Vec<D>) -> Vec<T>
+where
+    T: FromEnvString,
+    D: ToEnvString,
+{
+    get_vec_env_or(env_name, sep, |_| {
+        Ok(default.into_iter().map(EnvString::from).collect())
+    })
+    .unwrap_or_else(make_panic)
+}
+
+/// This function is similar as `get_vec_env_or_default`, but the default value will be set to environment
+/// variable, if env variable is missed.
+///
+/// Panics
+/// ------
+/// Application will panic if cannot parse variable to expected type
+///
+/// Example
+/// -------
+///
+/// ```rust
+/// # extern crate itconfig;
+/// # use itconfig::get_vec_env_or_set_default;
+/// use std::env;
+///
+/// fn main () {
+///     let result: Vec<bool> = get_vec_env_or_set_default("TESTING", ",", vec!["true"]);
+///     assert_eq!(result, vec![true]);
+///
+///     let var = env::var("TESTING").unwrap();
+///     assert_eq!(var, "true");
+/// }
+/// ```
+///
+pub fn get_vec_env_or_set_default<T, D>(
+    env_name: &str,
+    sep: &'static str,
+    default: Vec<D>,
+) -> Vec<T>
+where
+    T: FromEnvString,
+    D: ToEnvString,
+{
+    get_vec_env_or(env_name, sep, |_| {
+        let default_env_strings: Vec<EnvString> =
+            default.into_iter().map(EnvString::from).collect();
+        let env_val =
+            default_env_strings
+                .iter()
+                .enumerate()
+                .fold(String::new(), |mut res, (i, item)| {
+                    if i > 0 {
+                        res.push_str(sep);
+                    }
+                    res.push_str(&item);
+                    res
+                });
+        env::set_var(env_name, env_val.as_str());
+        Ok(default_env_strings)
+    })
+    .unwrap_or_else(make_panic)
+}
+
+/// This function returns env variable as `EnvString` structure. You can pass callback for custom
+/// default expression. Callback should return `EnvString` value or `EnvError`
+pub fn get_vec_env_or<T, F>(env_name: &str, sep: &'static str, cb: F) -> Result<Vec<T>, EnvError>
+where
+    T: FromEnvString,
+    F: FnOnce(env::VarError) -> Result<Vec<EnvString>, EnvError>,
+{
+    env::var(env_name)
+        .map(|s| {
+            s.split(sep)
+                .into_iter()
+                .map(|item| item.to_env_string())
+                .collect()
+        })
+        .or_else(cb)
+        .and_then(|items| {
+            items
+                .into_iter()
+                .map(|env_str| parse_env_variable(env_name, env_str))
+                .collect()
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SEP: &str = ",";
+
+    #[test]
+    #[should_panic(expected = "Environment variable \"TEST_CASE_VEC_1\" is missing")]
+    fn get_missing_vec_env() {
+        let _: Vec<&'static str> = get_vec_env_or_panic("TEST_CASE_VEC_1", SEP);
+    }
+
+    #[test]
+    #[should_panic(expected = "Failed to parse environment variable \"TEST_CASE_VEC_2\"")]
+    fn get_vec_env_with_invalid_value() {
+        let env_name = "TEST_CASE_VEC_2";
+        env::set_var(&env_name, "30r");
+        let _: Vec<u32> = get_vec_env_or_panic(env_name, SEP);
+    }
+
+    #[test]
+    fn get_result_of_missing_vec_env() {
+        let env_name = String::from("TEST_CASE_VEC_3");
+        let env_val = get_vec_env::<String>(&env_name, SEP);
+        assert_eq!(env_val, Err(EnvError::MissingVariable(env_name)))
+    }
+
+    #[test]
+    fn get_result_of_vec_env_with_invalid_value() {
+        let env_name = String::from("TEST_CASE_VEC_4");
+        env::set_var(&env_name, "30r");
+        let env_val = get_vec_env::<u32>(&env_name, SEP);
+        assert_eq!(env_val, Err(EnvError::FailedToParse(env_name)))
+    }
+
+    #[test]
+    fn get_result_of_vec_env_successfully() {
+        env::set_var("TEST_CASE_VEC_5", "30");
+        let env_var = get_vec_env("TEST_CASE_VEC_5", SEP);
+        assert_eq!(env_var, Ok(vec![30]));
+    }
+
+    #[test]
+    fn get_missing_vec_env_with_default_value() {
+        let flag: Vec<bool> = get_vec_env_or_default("TEST_CASE_VEC_6", SEP, vec!["true"]);
+        assert_eq!(flag, vec![true]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Failed to parse environment variable \"TEST_CASE_VEC_7\"")]
+    fn get_invalid_vec_env_with_default_value() {
+        env::set_var("TEST_CASE_VEC_7", "30r");
+        get_vec_env_or_default::<u32, _>("TEST_CASE_VEC_7", SEP, vec![30]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Failed to parse environment variable \"TEST_CASE_VEC_8\"")]
+    fn get_vec_env_with_invalid_default_value() {
+        get_vec_env_or_default::<u32, _>("TEST_CASE_VEC_8", SEP, vec!["30r"]);
+    }
+
+    #[test]
+    fn get_vec_env_with_default_successfully() {
+        env::set_var("TEST_CASE_VEC_9", "10");
+        let env_val: Vec<u32> = get_vec_env_or_default("TEST_CASE_VEC_9", SEP, vec![30]);
+        assert_eq!(env_val, vec![10])
+    }
+
+    #[test]
+    fn get_missing_vec_env_with_set_default_value() {
+        let flag: Vec<bool> = get_vec_env_or_set_default("TEST_CASE_VEC_10", SEP, vec!["true"]);
+        assert_eq!(flag, vec![true]);
+
+        let env_var = env::var("TEST_CASE_VEC_10");
+        assert_eq!(env_var, Ok(String::from("true")))
+    }
+
+    #[test]
+    fn get_optional_vec_env() {
+        env::set_var("TEST_CASE_VEC_11", "something");
+        let something: Option<Vec<&'static str>> = maybe_get_vec_env("TEST_CASE_VEC_11", SEP);
+        assert_eq!(something, Some(vec!["something"]));
+
+        let nothing: Option<Vec<&'static str>> = maybe_get_vec_env("TEST_CASE_VEC_11_NONE", SEP);
+        assert_eq!(nothing, None);
+    }
+
+    #[test]
+    fn get_custom_type_from_vec_env() {
+        #[derive(Debug, PartialEq, Eq)]
+        enum PaymentPlatform {
+            PayPal,
+            Stripe,
+            SomethingElse,
+        }
+
+        impl FromEnvString for PaymentPlatform {
+            type Err = &'static str;
+
+            fn from_env_string(envstr: &EnvString) -> Result<Self, Self::Err> {
+                match envstr.to_lowercase().as_str() {
+                    "paypal" => Ok(Self::PayPal),
+                    "stripe" => Ok(Self::Stripe),
+                    "smth" => Ok(Self::SomethingElse),
+                    _ => Err("Unsupported payment platform"),
+                }
+            }
+        }
+
+        env::set_var("TEST_CASE_VEC_12", "paypal,stripe");
+        let something: Option<Vec<PaymentPlatform>> = maybe_get_vec_env("TEST_CASE_VEC_12", SEP);
+        assert_eq!(
+            something,
+            Some(vec![PaymentPlatform::PayPal, PaymentPlatform::Stripe])
+        );
+    }
+}

--- a/itconfig/src/lib.rs
+++ b/itconfig/src/lib.rs
@@ -149,11 +149,14 @@
 
 mod envstr;
 mod error;
-mod getenv;
+mod get_env;
+mod get_vec_env;
+pub(crate) mod utils;
 
 pub use self::envstr::*;
 pub use self::error::*;
-pub use self::getenv::*;
+pub use self::get_env::*;
+pub use self::get_vec_env::*;
 
 #[cfg(feature = "macro")]
 extern crate itconfig_macro;

--- a/itconfig/src/utils.rs
+++ b/itconfig/src/utils.rs
@@ -1,0 +1,13 @@
+use crate::{EnvError, EnvString, FromEnvString};
+
+pub(crate) fn parse_env_variable<T>(env_name: &str, env_str: EnvString) -> Result<T, EnvError>
+where
+    T: FromEnvString,
+{
+    FromEnvString::from_env_string(&env_str)
+        .map_err(|_| EnvError::FailedToParse(env_name.to_string()))
+}
+
+pub(crate) fn make_panic<T>(e: EnvError) -> T {
+    panic!("{}", e)
+}

--- a/itconfig/src/utils.rs
+++ b/itconfig/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::{EnvError, EnvString, FromEnvString};
+use crate::{EnvError, EnvString, FromEnvString, ToEnvString};
 
 pub(crate) fn parse_env_variable<T>(env_name: &str, env_str: EnvString) -> Result<T, EnvError>
 where
@@ -10,4 +10,24 @@ where
 
 pub(crate) fn make_panic<T>(e: EnvError) -> T {
     panic!("{}", e)
+}
+
+pub(crate) fn join(env_strings: &[EnvString], sep: &str) -> String {
+    env_strings
+        .iter()
+        .enumerate()
+        .fold(String::new(), |mut res, (i, item)| {
+            if i > 0 {
+                res.push_str(sep);
+            }
+            res.push_str(&item);
+            res
+        })
+}
+
+pub(crate) fn vec_to_env_strings<T>(values: Vec<T>) -> Vec<EnvString>
+where
+    T: ToEnvString,
+{
+    values.into_iter().map(EnvString::from).collect()
 }


### PR DESCRIPTION
I've added support for Vec type.

- added functions to read env var into the Vec
- added support in macro

See full example bellow



```rust
extern crate itconfig;
use itconfig::*;
use std::env;

#[derive(Debug, PartialEq, Eq)]
enum PaymentPlatform {
    PayPal,
    Stripe,
    SomethingElse,
}

impl FromEnvString for PaymentPlatform {
    type Err = &'static str;

    fn from_env_string(envstr: &EnvString) -> Result<Self, Self::Err> {
        match envstr.to_lowercase().as_str() {
            "paypal" => Ok(Self::PayPal),
            "stripe" => Ok(Self::Stripe),
            "smth" => Ok(Self::SomethingElse),
            _ => Err("Unsupported payment platform"),
        }
    }
}


fn main () {
    env::set_var("PAYMENT_PLATFORMS", "paypal,stripe");

    let payment_platforms: Option<Vec<PaymentPlatform>> = maybe_get_vec_env("PAYMENT_PLATFORMS", ",");
    assert_eq!(
        payment_platforms,
        Some(vec![PaymentPlatform::PayPal, PaymentPlatform::Stripe])
    );
}
```